### PR TITLE
Feature: Add auth bearer token support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ async def generate_echo_response(context: RequestContext) -> Response | None:
 If the generator function returns a `Response` object then that response is used as the response for the request.
 If the generator function returns `None` then the next generator function is called.
 
+### Adding custom bearer token authentication
+
+The simulator expects either an `api-key` or `ocp-apim-subscription-key` header with a valid key for every request. To enable bearer token authentication you can intialize your custom extension with a valid `auth_bearer_token` as follows:
+
+```python
+def initialize(config: Config):
+    # token defined below will allow requests to your extension
+    # with header 'Authorization: Bearer your-bearer-token'
+    config.auth_bearer_token('your-bearer-token')
+```
 
 ### Running with an extension
 

--- a/src/aoai-simulated-api/src/aoai_simulated_api/app_builder.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/app_builder.py
@@ -62,16 +62,25 @@ def get_simulator(logger: logging.Logger, config: Config) -> FastAPI:
 
     # api-key header for OpenAI
     # ocp-apim-subscription-key header for doc intelligence
+    # auth bearer token for custom endpoints
     api_key_header_scheme = APIKeyHeader(name="api-key", auto_error=False)
     ocp_apim_subscription_key_header_scheme = APIKeyHeader(name="ocp-apim-subscription-key", auto_error=False)
+    auth_bearer_token_header_scheme = APIKeyHeader(name="Authorization", auto_error=False)
 
     def validate_api_key(
         api_key: Annotated[str, Depends(api_key_header_scheme)],
         ocp_apim_subscription_key: Annotated[str, Depends(ocp_apim_subscription_key_header_scheme)],
+        auth_bearer_token: Annotated[str, Depends(auth_bearer_token_header_scheme)],
     ):
         if api_key and secrets.compare_digest(api_key, config.simulator_api_key):
             return True
         if ocp_apim_subscription_key and secrets.compare_digest(ocp_apim_subscription_key, config.simulator_api_key):
+            return True
+        if (
+            auth_bearer_token
+            and config.auth_bearer_token
+            and secrets.compare_digest(auth_bearer_token, f"Bearer {config.auth_bearer_token}")
+        ):
             return True
 
         logger.warning("🔒 Missing or incorrect API Key provided")

--- a/src/aoai-simulated-api/src/aoai_simulated_api/app_builder.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/app_builder.py
@@ -76,11 +76,9 @@ def get_simulator(logger: logging.Logger, config: Config) -> FastAPI:
             return True
         if ocp_apim_subscription_key and secrets.compare_digest(ocp_apim_subscription_key, config.simulator_api_key):
             return True
-        if (
-            auth_bearer_token
-            and config.auth_bearer_token
-            and secrets.compare_digest(auth_bearer_token, f"Bearer {config.auth_bearer_token}")
-        ):
+
+        auth_bearer_token_config = getattr(config, "auth_bearer_token", None)
+        if auth_bearer_token and secrets.compare_digest(auth_bearer_token, f"Bearer {auth_bearer_token_config}"):
             return True
 
         logger.warning("🔒 Missing or incorrect API Key provided")


### PR DESCRIPTION
Custom generators/forwarders don't necessarily have an `api-key` or `ocp-apim-subscription-key` header set. 

This PR allows you to specify a custom bearer token to pass the `validate_api_key()` and send a response