### PR TITLE
Feature: Build ghcr package

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./src/aoai-simulated-api
+        file: ./src/aoai-simulated-api/Dockerfile
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/aoai-simulated-api:latest


### PR DESCRIPTION
Creating a GHCR image allows easy extension, without creating a local copy of the simulator.

Example here, leveraging this:
https://github.com/bart-jansen/api-simulator

Dockerfile copies all content into container and creates a new image with the pdfs, new endpoints and openai configuration.
