### PR TITLE
Minor tweaks/fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set bash scripts and .env files to use LF line endings regardless of the platform
+# used to clone the code
+*.sh text eol=lf
+*.env text eol=lf

--- a/src/aoai-simulated-api/src/aoai_simulated_api/app_builder.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/app_builder.py
@@ -130,8 +130,6 @@ def config_patch(config: dict, _: Annotated[bool, Depends(_default_validate_api_
 @app.api_route("/{full_path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def catchall(request: Request):
     logger.debug("⚡ handling route: %s", request.url.path)
-    # TODO check for traceparent in inbound request and propagate
-    #      to allow for correlating load test with back-end data
 
     response = None
     context = RequestContext(config=get_config(), request=request)

--- a/src/aoai-simulated-api/src/aoai_simulated_api/generator/openai_tokens.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/generator/openai_tokens.py
@@ -6,6 +6,19 @@ logger = logging.getLogger(__name__)
 # For details on the token counting, see https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
 
 
+def get_max_completion_tokens(request_body, model_name: str, prompt_tokens: int) -> int:
+    max_tokens = request_body.get("max_tokens")
+
+    # Based on https://platform.openai.com/docs/guides/text-generation/managing-tokens
+    default_max_tokens = 128000 if model_name == "gpt-4o" else 4097
+
+    upper_limit = default_max_tokens - prompt_tokens
+    if max_tokens is None or max_tokens > upper_limit:
+        max_tokens = upper_limit
+
+    return max_tokens
+
+
 def num_tokens_from_string(string: str, model: str) -> int:
     """Returns the number of tokens in a text string."""
     try:

--- a/src/aoai-simulated-api/src/aoai_simulated_api/record_replay/handler.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/record_replay/handler.py
@@ -196,13 +196,12 @@ class RecordReplayHandler:
                 "headers": request_headers,
                 "body": request_body,
             },
-            status_message="n/a",
             duration_ms=elapsed_time_ms,
         )
 
         return recorded_response
 
-    def store_recorded_response(self, request, recorded_response):
+    def store_recorded_response(self, request: fastapi.Request, recorded_response: RecordedResponse):
         logger.info("📝 Storing recording for %s %s", request.method, request.url)
         recording = self._recordings.get(request.url.path)
         if not recording:

--- a/src/aoai-simulated-api/src/aoai_simulated_api/record_replay/models.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/record_replay/models.py
@@ -6,7 +6,6 @@ from fastapi import Request
 class RecordedResponse:
     request_hash: int
     status_code: int
-    status_message: str
     headers: dict[str, list[str]]
     body: str
     duration_ms: int

--- a/src/aoai-simulated-api/src/aoai_simulated_api/record_replay/persistence.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/record_replay/persistence.py
@@ -18,7 +18,7 @@ class YamlRecordingPersister:
             interaction = {
                 "request": recorded_response.full_request,
                 "response": {
-                    "status": {"code": recorded_response.status_code, "message": recorded_response.status_message},
+                    "status": {"code": recorded_response.status_code},
                     "headers": recorded_response.headers,
                     "body": {"string": recorded_response.body},
                     "duration_ms": recorded_response.duration_ms,
@@ -38,7 +38,7 @@ class YamlRecordingPersister:
         if not os.path.exists(self._recording_dir):
             os.mkdir(self._recording_dir)
 
-    def get_recording_file_path(self, url):
+    def get_recording_file_path(self, url: str):
         query_start = url.find("?")
         if query_start != -1:
             url = url[:query_start]
@@ -71,7 +71,6 @@ class YamlRecordingPersister:
                 recording[request_hash] = RecordedResponse(
                     request_hash=request_hash,
                     status_code=response["status"]["code"],
-                    status_message=response["status"]["message"],
                     headers=response["headers"],
                     body=response["body"]["string"],
                     context_values=context_values,

--- a/src/examples/generator_replace_chat_completion/generator_config.py
+++ b/src/examples/generator_replace_chat_completion/generator_config.py
@@ -69,6 +69,6 @@ async def custom_azure_openai_chat_completion(context: RequestContext) -> Respon
     )
 
     # calculate a simulated latency and store in context.values
-    calculate_latency(context, status_code=response.status_code)
+    await calculate_latency(context, status_code=response.status_code)
 
     return response

--- a/src/examples/generator_replace_chat_completion/generator_config.py
+++ b/src/examples/generator_replace_chat_completion/generator_config.py
@@ -51,10 +51,10 @@ async def custom_azure_openai_chat_completion(context: RequestContext) -> Respon
     model_name = get_model_name_from_deployment_name(context, deployment_name)
     messages = request_body["messages"]
 
-    # Here we fix the number of words to generate to 1 and set the finish_reason to "stop".
+    # Here we fix the max_tokens 10 and set the finish_reason to "stop".
     # In a more realistic extension you would add logic to tailor the response sizes
     # or finish_reason based on the input messages observed in your system.
-    words_to_generate = 1
+    max_tokens = 10
     finish_reason = "stop"
 
     streaming = request_body.get("stream", False)
@@ -63,7 +63,7 @@ async def custom_azure_openai_chat_completion(context: RequestContext) -> Respon
         deployment_name=deployment_name,
         model_name=model_name,
         streaming=streaming,
-        words_to_generate=words_to_generate,
+        max_tokens=max_tokens,
         prompt_messages=messages,
         finish_reason=finish_reason,
     )


### PR DESCRIPTION
- Add missing `await` on `calculate_latency` call in example generator
- Remove unused persisted field (`status_message`)
- Remove outdated TODO comment
- Add test for streaming chat completion
- Ensure generated response is within max_token limit (closes #34 )
- Add `.gitattributes` to force LF line endings for `.sh`/`.env` files