### PR TITLE
Add ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Enable adding custom rate limiters
   - Move latency calculation to generators. This allows for extensions to customise latency values. NOTE: If you have custom generators they need to be updated to handle this (see examples for implementation details)
 - Add rate-limiting for replayed requests
+- Add `ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS ` configuration option to control whether the simulator will generate responses for any deployment or only known deployments
 
 
 ## v0.3 2024-05-03

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,11 +1,11 @@
 # Configuring the simulator
 
 - [Configuring the simulator](#configuring-the-simulator)
-	- [Environment variables](#environment-variables)
-	- [Latency](#latency)
-	- [Rate Limiting](#rate-limiting)
-	- [Large recordings](#large-recordings)
-	- [Config API Endpoint](#config-api-endpoint)
+  - [Environment variables](#environment-variables)
+  - [Latency](#latency)
+  - [Rate Limiting](#rate-limiting)
+  - [Large recordings](#large-recordings)
+  - [Config API Endpoint](#config-api-endpoint)
 
 There are a number of [environment variables](#environment-variables) that can be used to configure the simulator.
 Additionally, some configuration can be changed while the simulator is running using the [config endpoint](#config-endpoint).
@@ -20,6 +20,7 @@ When running the simulated API, there are a number of environment variables to c
 | `SIMULATOR_API_KEY`             | The API key used by the simulator to authenticate requests. If not specified a key is auto-generated (see the logs). It is recommended to set a deterministic key value in `.env` |
 | `RECORDING_DIR`                 | The directory to store the recorded requests and responses (defaults to `.recording`).                                                                                            |
 | `OPENAI_DEPLOYMENT_CONFIG_PATH` | The path to a JSON file that contains the deployment configuration. See [OpenAI Rate-Limiting](#rate-limiting)                                                             |
+| `ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS`| If set to `True` (default), the simulator will generate OpenAI responses for any deployment. If set to `False`, the simulator will only generate responses for known deployments. |
 | `AZURE_OPENAI_ENDPOINT`         | The endpoint for the Azure OpenAI service, e.g. `https://mysvc.openai.azure.com/`. Used when forwarding requests.                                                                 |
 | `AZURE_OPENAI_KEY`              | The API key for the Azure OpenAI service. Used when forwarding requests                                                                                                           |
 | `LOG_LEVEL`                     | The log level for the simulator. Defaults to `INFO`.                                                                                                                              |

--- a/sample.env
+++ b/sample.env
@@ -5,6 +5,9 @@ LOCATION='northcentralus'
 # Add values to configure the simulator (see README.md)
 SIMULATOR_MODE=generate
 
+# Set this to False to return 404 for deployments that aren't configured
+ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS=True
+
 
 # Set metric export interval (milliseconds)
 OTEL_METRIC_EXPORT_INTERVAL=10000

--- a/src/aoai-simulated-api/src/aoai_simulated_api/config_loader.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/config_loader.py
@@ -19,6 +19,9 @@ def get_config_from_env_vars(logger: logging.Logger) -> Config:
 
     config.recording.forwarders = get_default_forwarders()
     config.openai_deployments = _load_openai_deployments(logger)
+    if not config.openai_deployments:
+        logger.info("OpenAI deployments not set - using default OpenAI deployments")
+        config.openai_deployments = _default_openai_deployments()
 
     initialize_config(config)
     return config
@@ -55,6 +58,37 @@ def _load_openai_deployments(logger: logging.Logger) -> dict[str, OpenAIDeployme
             tokens_per_minute=deployment["tokensPerMinute"],
         )
     return deployments
+
+
+def _default_openai_deployments() -> dict[str, OpenAIDeployment]:
+    # Default set of OpenAI deployment configurations for when none are provided
+    return {
+        "embedding": OpenAIDeployment(name="embedding", model="text-embedding-ada-002", tokens_per_minute=10000),
+        "gpt-35-turbo-1k-token": OpenAIDeployment(
+            name="gpt-35-turbo-1k-token", model="gpt-3.5-turbo", tokens_per_minute=1000
+        ),
+        "gpt-35-turbo-2k-token": OpenAIDeployment(
+            name="gpt-35-turbo-2k-token", model="gpt-3.5-turbo", tokens_per_minute=2000
+        ),
+        "gpt-35-turbo-5k-token": OpenAIDeployment(
+            name="gpt-35-turbo-5k-token", model="gpt-3.5-turbo", tokens_per_minute=5000
+        ),
+        "gpt-35-turbo-10k-token": OpenAIDeployment(
+            name="gpt-35-turbo-10k-token", model="gpt-3.5-turbo", tokens_per_minute=10000
+        ),
+        "gpt-35-turbo-20k-token": OpenAIDeployment(
+            name="gpt-35-turbo-20k-token", model="gpt-3.5-turbo", tokens_per_minute=20000
+        ),
+        "gpt-35-turbo-50k-token": OpenAIDeployment(
+            name="gpt-35-turbo-50k-token", model="gpt-3.5-turbo", tokens_per_minute=50000
+        ),
+        "gpt-35-turbo-100k-token": OpenAIDeployment(
+            name="gpt-35-turbo-100k-token", model="gpt-3.5-turbo", tokens_per_minute=100000
+        ),
+        "gpt-35-turbo-100m-token": OpenAIDeployment(
+            name="gpt-35-turbo-100m-token", model="gpt-3.5-turbo", tokens_per_minute=100000000
+        ),
+    }
 
 
 def load_extension(config: Config):

--- a/src/aoai-simulated-api/src/aoai_simulated_api/models.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/models.py
@@ -129,6 +129,7 @@ class PatchableConfig(BaseSettings):
     recording: RecordingConfig = Field(default=RecordingConfig())
     openai_deployments: dict[str, "OpenAIDeployment"] | None = Field(default=None)
     latency: Annotated[LatencyConfig, Field(default=LatencyConfig())]
+    allow_undefined_openai_deployments: bool = Field(default=True, alias="ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS")
 
 
 class Config(PatchableConfig):

--- a/src/examples/generator_replace_chat_completion/generator_config.py
+++ b/src/examples/generator_replace_chat_completion/generator_config.py
@@ -1,6 +1,7 @@
 # This file is an example of how you can define your generators
 # Generators can be sync or async methods
 
+import json
 
 from aoai_simulated_api.auth import validate_api_key_header
 from aoai_simulated_api.models import Config, RequestContext
@@ -49,6 +50,14 @@ async def custom_azure_openai_chat_completion(context: RequestContext) -> Respon
     request_body = await request.json()
     deployment_name = path_params["deployment"]
     model_name = get_model_name_from_deployment_name(context, deployment_name)
+    if model_name is None:
+        return Response(
+            status_code=404,
+            content=json.dumps({"error": f"Deployment {deployment_name} not found"}),
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
     messages = request_body["messages"]
 
     # Here we fix the max_tokens 10 and set the finish_reason to "stop".

--- a/src/tests/test_openai_generator_chat_completion.py
+++ b/src/tests/test_openai_generator_chat_completion.py
@@ -11,7 +11,7 @@ from aoai_simulated_api.models import (
     OpenAIDeployment,
 )
 from aoai_simulated_api.generator.manager import get_default_generators
-from openai import AzureOpenAI, AuthenticationError, RateLimitError, Stream
+from openai import AzureOpenAI, AuthenticationError, NotFoundError, RateLimitError, Stream
 from openai.types.chat import ChatCompletionChunk
 import pytest
 
@@ -46,54 +46,7 @@ def _get_generator_config(extension_path: str | None = None) -> Config:
 
 
 @pytest.mark.asyncio
-async def test_openai_generator_completion_requires_auth():
-    """
-    Ensure we need the right API key to call the completion endpoint
-    """
-    config = _get_generator_config()
-    server = UvicornTestServer(config)
-    with server.run_in_thread():
-        aoai_client = AzureOpenAI(
-            api_key="wrong_key",
-            api_version="2023-12-01-preview",
-            azure_endpoint="http://localhost:8001",
-            max_retries=0,
-        )
-        prompt = "This is a test prompt"
-
-        try:
-            aoai_client.completions.create(model="deployment1", prompt=prompt, max_tokens=50)
-            assert False, "Expected an exception"
-        except AuthenticationError as e:
-            assert e.status_code == 401
-            assert e.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
-
-
-@pytest.mark.asyncio
-async def test_openai_generator_completion_success():
-    """
-    Ensure we can call the completion endpoint using the generator
-    """
-    config = _get_generator_config()
-    server = UvicornTestServer(config)
-    with server.run_in_thread():
-        aoai_client = AzureOpenAI(
-            api_key=API_KEY,
-            api_version="2023-12-01-preview",
-            azure_endpoint="http://localhost:8001",
-            max_retries=0,
-        )
-        prompt = "This is a test prompt"
-        max_tokens = 50
-        response = aoai_client.completions.create(model="deployment1", prompt=prompt, max_tokens=max_tokens)
-
-        assert len(response.choices) == 1
-        assert len(response.choices[0].text) > 50
-        assert response.usage.completion_tokens <= max_tokens
-
-
-@pytest.mark.asyncio
-async def test_openai_generator_chat_completion_requires_auth():
+async def test_requires_auth():
     """
     Ensure we need the right API key to call the chat completion endpoint
     """
@@ -117,7 +70,7 @@ async def test_openai_generator_chat_completion_requires_auth():
 
 
 @pytest.mark.asyncio
-async def test_openai_generator_chat_completion_success():
+async def test_success():
     """
     Ensure we can call the chat completion endpoint using the generator
     """
@@ -142,7 +95,56 @@ async def test_openai_generator_chat_completion_success():
 
 
 @pytest.mark.asyncio
-async def test_openai_generator_chat_completion_max_tokens():
+async def test_requires_known_deployment_when_config_set():
+    """
+    Test that the generator requires a known deployment when the ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config is set to False
+    """
+    config = _get_generator_config()
+    config.allow_undefined_openai_deployments = False
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        messages = [{"role": "user", "content": "What is the meaning of life?"}]
+        max_tokens = 50
+        try:
+            aoai_client.chat.completions.create(model="_unknown_deployment_", messages=messages, max_tokens=max_tokens)
+            assert False, "Expected 404 error"
+        except NotFoundError as e:
+            assert e.status_code == 404
+            assert e.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
+
+
+@pytest.mark.asyncio
+async def test_allows_unknown_deployment_when_config_not_set():
+    """
+    Test that the generator allows an unknown deployment when the ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config is set to True
+    """
+    config = _get_generator_config()
+    config.allow_undefined_openai_deployments = True
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        messages = [{"role": "user", "content": "What is the meaning of life?"}]
+        max_tokens = 50
+        response = aoai_client.chat.completions.create(
+            model="_unknown_deployment_", messages=messages, max_tokens=max_tokens
+        )
+
+        assert len(response.choices) == 1
+
+
+@pytest.mark.asyncio
+async def test_max_tokens():
     """
     Ensure we can call the chat completion endpoint using the generator
     """
@@ -167,7 +169,7 @@ async def test_openai_generator_chat_completion_max_tokens():
 
 
 @pytest.mark.asyncio
-async def test_openai_generator_chat_completion_stream_success():
+async def test_stream_success():
     """
     Ensure we can call the chat completion endpoint using the generator with a streamed response
     """
@@ -200,54 +202,7 @@ async def test_openai_generator_chat_completion_stream_success():
 
 
 @pytest.mark.asyncio
-async def test_openai_generator_embeddings_requires_auth():
-    """
-    Ensure we need the right API key to call the embeddings endpoint
-    """
-    config = _get_generator_config()
-    server = UvicornTestServer(config)
-    with server.run_in_thread():
-        aoai_client = AzureOpenAI(
-            api_key="wrong_key",
-            api_version="2023-12-01-preview",
-            azure_endpoint="http://localhost:8001",
-            max_retries=0,
-        )
-        content = "This is some text to generate embeddings for"
-
-        try:
-            aoai_client.embeddings.create(model="deployment1", input=content)
-            assert False, "Expected an exception"
-        except AuthenticationError as e:
-            assert e.status_code == 401
-            assert e.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
-
-
-@pytest.mark.asyncio
-async def test_openai_generator_embeddings_success():
-    """
-    Ensure we can call the embeddings endpoint using the generator
-    """
-    config = _get_generator_config()
-    server = UvicornTestServer(config)
-    with server.run_in_thread():
-        aoai_client = AzureOpenAI(
-            api_key=API_KEY,
-            api_version="2023-12-01-preview",
-            azure_endpoint="http://localhost:8001",
-            max_retries=0,
-        )
-        content = "This is some text to generate embeddings for"
-        response = aoai_client.embeddings.create(model="deployment1", input=content)
-
-        assert len(response.data) == 1
-        assert response.data[0].object == "embedding"
-        assert response.data[0].index == 0
-        assert len(response.data[0].embedding) == 1536
-
-
-@pytest.mark.asyncio
-async def test_openai_generator_chat_completion_with_custom_generator():
+async def test_custom_generator():
     """
     Ensure we can call the chat completion endpoint using a generator from an extension
     """
@@ -268,39 +223,3 @@ async def test_openai_generator_chat_completion_with_custom_generator():
         assert response.choices[0].message.role == "assistant"
         assert response.usage.completion_tokens <= 10, "Custom generator hard-codes max_tokens to 10"
         assert response.choices[0].finish_reason == "stop"
-
-
-@pytest.mark.asyncio
-async def test_openai_generator_embeddings_limit_reached():
-    """
-    Ensure we can call the chat completions endpoint multiple times using the generator to trigger rate-limiting
-    """
-    config = _get_generator_config()
-    server = UvicornTestServer(config)
-    with server.run_in_thread():
-        aoai_client = AzureOpenAI(
-            api_key=API_KEY,
-            api_version="2023-12-01-preview",
-            azure_endpoint="http://localhost:8001",
-            max_retries=0,
-        )
-        messages = [{"role": "user", "content": "What is the meaning of life?"}]
-        response = aoai_client.chat.completions.create(model="low_limit", messages=messages, max_tokens=50)
-
-        assert len(response.choices) == 1
-        assert response.choices[0].message.role == "assistant"
-        assert len(response.choices[0].message.content) > 20
-        assert response.choices[0].finish_reason == "length"
-
-        # The total token count for the request is roughly 60 tokens
-        # "low_limit" deployment has a rate limit of 600 tokens per minute
-        # Which is 100 every 10s, so our second request should trigger the rate-limiting
-        try:
-            aoai_client.chat.completions.create(model="low_limit", messages=messages, max_tokens=50)
-            assert False, "Expect to be rate-limited"
-        except RateLimitError as e:
-            assert e.status_code == 429
-            assert (
-                e.message
-                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
-            )

--- a/src/tests/test_openai_generator_completion.py
+++ b/src/tests/test_openai_generator_completion.py
@@ -1,0 +1,139 @@
+"""
+Test the OpenAI generator endpoints
+"""
+
+from aoai_simulated_api.models import (
+    Config,
+    LatencyConfig,
+    ChatCompletionLatency,
+    CompletionLatency,
+    EmbeddingLatency,
+    OpenAIDeployment,
+)
+from aoai_simulated_api.generator.manager import get_default_generators
+from openai import AzureOpenAI, AuthenticationError, NotFoundError, RateLimitError, Stream
+from openai.types.chat import ChatCompletionChunk
+import pytest
+
+from .test_uvicorn_server import UvicornTestServer
+
+API_KEY = "123456789"
+
+
+def _get_generator_config(extension_path: str | None = None) -> Config:
+    config = Config(generators=get_default_generators())
+    config.simulator_api_key = API_KEY
+    config.simulator_mode = "generate"
+    config.latency = LatencyConfig(
+        open_ai_completions=CompletionLatency(
+            LATENCY_OPENAI_COMPLETIONS_MEAN=0,
+            LATENCY_OPENAI_COMPLETIONS_STD_DEV=0.1,
+        ),
+        open_ai_chat_completions=ChatCompletionLatency(
+            LATENCY_OPENAI_CHAT_COMPLETIONS_MEAN=0,
+            LATENCY_OPENAI_CHAT_COMPLETIONS_STD_DEV=0.1,
+        ),
+        open_ai_embeddings=EmbeddingLatency(
+            LATENCY_OPENAI_EMBEDDINGS_MEAN=0,
+            LATENCY_OPENAI_EMBEDDINGS_STD_DEV=0.1,
+        ),
+    )
+    config.openai_deployments = {
+        "low_limit": OpenAIDeployment(name="low_limit", model="gpt-3.5-turbo", tokens_per_minute=64 * 6)
+    }
+    config.extension_path = extension_path
+    return config
+
+
+@pytest.mark.asyncio
+async def test_requires_auth():
+    """
+    Ensure we need the right API key to call the completion endpoint
+    """
+    config = _get_generator_config()
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key="wrong_key",
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        prompt = "This is a test prompt"
+
+        try:
+            aoai_client.completions.create(model="deployment1", prompt=prompt, max_tokens=50)
+            assert False, "Expected an exception"
+        except AuthenticationError as e:
+            assert e.status_code == 401
+            assert e.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
+
+
+@pytest.mark.asyncio
+async def test_success():
+    """
+    Ensure we can call the completion endpoint using the generator
+    """
+    config = _get_generator_config()
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        prompt = "This is a test prompt"
+        max_tokens = 50
+        response = aoai_client.completions.create(model="deployment1", prompt=prompt, max_tokens=max_tokens)
+
+        assert len(response.choices) == 1
+        assert len(response.choices[0].text) > 50
+        assert response.usage.completion_tokens <= max_tokens
+
+
+@pytest.mark.asyncio
+async def test_requires_known_deployment_when_config_set():
+    """
+    Test that the generator requires a known deployment when the ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config is set to False
+    """
+    config = _get_generator_config()
+    config.allow_undefined_openai_deployments = False
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        prompt = "This is a test prompt"
+        max_tokens = 50
+        try:
+            aoai_client.completions.create(model="_unknown_deployment_", prompt=prompt, max_tokens=max_tokens)
+            assert False, "Expected 404 error"
+        except NotFoundError as e:
+            assert e.status_code == 404
+            assert e.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
+
+
+@pytest.mark.asyncio
+async def test_allows_unknown_deployment_when_config_not_set():
+    """
+    Test that the generator allows an unknown deployment when the ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config is set to True
+    """
+    config = _get_generator_config()
+    config.allow_undefined_openai_deployments = True
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        prompt = "This is a test prompt"
+        max_tokens = 50
+        response = aoai_client.completions.create(model="_unknown_deployment_", prompt=prompt, max_tokens=max_tokens)
+
+        assert len(response.choices) == 1

--- a/src/tests/test_openai_generator_embeddings.py
+++ b/src/tests/test_openai_generator_embeddings.py
@@ -1,0 +1,173 @@
+"""
+Test the OpenAI generator endpoints
+"""
+
+from aoai_simulated_api.models import (
+    Config,
+    LatencyConfig,
+    ChatCompletionLatency,
+    CompletionLatency,
+    EmbeddingLatency,
+    OpenAIDeployment,
+)
+from aoai_simulated_api.generator.manager import get_default_generators
+from openai import AzureOpenAI, AuthenticationError, NotFoundError, RateLimitError, Stream
+from openai.types.chat import ChatCompletionChunk
+import pytest
+
+from .test_uvicorn_server import UvicornTestServer
+
+API_KEY = "123456789"
+
+
+def _get_generator_config(extension_path: str | None = None) -> Config:
+    config = Config(generators=get_default_generators())
+    config.simulator_api_key = API_KEY
+    config.simulator_mode = "generate"
+    config.latency = LatencyConfig(
+        open_ai_completions=CompletionLatency(
+            LATENCY_OPENAI_COMPLETIONS_MEAN=0,
+            LATENCY_OPENAI_COMPLETIONS_STD_DEV=0.1,
+        ),
+        open_ai_chat_completions=ChatCompletionLatency(
+            LATENCY_OPENAI_CHAT_COMPLETIONS_MEAN=0,
+            LATENCY_OPENAI_CHAT_COMPLETIONS_STD_DEV=0.1,
+        ),
+        open_ai_embeddings=EmbeddingLatency(
+            LATENCY_OPENAI_EMBEDDINGS_MEAN=0,
+            LATENCY_OPENAI_EMBEDDINGS_STD_DEV=0.1,
+        ),
+    )
+    config.openai_deployments = {
+        "low_limit": OpenAIDeployment(name="low_limit", model="gpt-3.5-turbo", tokens_per_minute=64 * 6)
+    }
+    config.extension_path = extension_path
+    return config
+
+
+@pytest.mark.asyncio
+async def test_requires_auth():
+    """
+    Ensure we need the right API key to call the embeddings endpoint
+    """
+    config = _get_generator_config()
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key="wrong_key",
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        content = "This is some text to generate embeddings for"
+
+        try:
+            aoai_client.embeddings.create(model="deployment1", input=content)
+            assert False, "Expected an exception"
+        except AuthenticationError as e:
+            assert e.status_code == 401
+            assert e.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
+
+
+@pytest.mark.asyncio
+async def test_success():
+    """
+    Ensure we can call the embeddings endpoint using the generator
+    """
+    config = _get_generator_config()
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        content = "This is some text to generate embeddings for"
+        response = aoai_client.embeddings.create(model="deployment1", input=content)
+
+        assert len(response.data) == 1
+        assert response.data[0].object == "embedding"
+        assert response.data[0].index == 0
+        assert len(response.data[0].embedding) == 1536
+
+
+@pytest.mark.asyncio
+async def test_limit_reached():
+    """
+    Ensure we can call the chat completions endpoint multiple times using the generator to trigger rate-limiting
+    """
+    config = _get_generator_config()
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        messages = [{"role": "user", "content": "What is the meaning of life?"}]
+        response = aoai_client.chat.completions.create(model="low_limit", messages=messages, max_tokens=50)
+
+        assert len(response.choices) == 1
+        assert response.choices[0].message.role == "assistant"
+        assert len(response.choices[0].message.content) > 20
+        assert response.choices[0].finish_reason == "length"
+
+        # The total token count for the request is roughly 60 tokens
+        # "low_limit" deployment has a rate limit of 600 tokens per minute
+        # Which is 100 every 10s, so our second request should trigger the rate-limiting
+        try:
+            aoai_client.chat.completions.create(model="low_limit", messages=messages, max_tokens=50)
+            assert False, "Expect to be rate-limited"
+        except RateLimitError as e:
+            assert e.status_code == 429
+            assert (
+                e.message
+                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_requires_known_deployment_when_config_set():
+    """
+    Test that the generator requires a known deployment when the ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config is set to False
+    """
+    config = _get_generator_config()
+    config.allow_undefined_openai_deployments = False
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        content = "This is some text to generate embeddings for"
+        try:
+            aoai_client.embeddings.create(model="_unknown_deployment_", input=content)
+            assert False, "Expected 404 error"
+        except NotFoundError as e:
+            assert e.status_code == 404
+            assert e.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
+
+
+@pytest.mark.asyncio
+async def test_allows_unknown_deployment_when_config_not_set():
+    """
+    Test that the generator allows an unknown deployment when the ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config is set to True
+    """
+    config = _get_generator_config()
+    config.allow_undefined_openai_deployments = True
+    server = UvicornTestServer(config)
+    with server.run_in_thread():
+        aoai_client = AzureOpenAI(
+            api_key=API_KEY,
+            api_version="2023-12-01-preview",
+            azure_endpoint="http://localhost:8001",
+            max_retries=0,
+        )
+        content = "This is some text to generate embeddings for"
+        response = aoai_client.embeddings.create(model="_unknown_deployment_", input=content)
+
+        assert len(response.data) == 1

--- a/test-aoai.http
+++ b/test-aoai.http
@@ -16,7 +16,7 @@
 
 POST {{aoai_endpoint}}openai/deployments/{{aoai_deployment}}/completions?api-version=2023-05-15
 Content-Type: application/json
-api-key: {{aoai_key}}xx
+api-key: {{aoai_key}}
 
 {
   "model": "gpt-5-turbo-1",


### PR DESCRIPTION
- Add ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS config option to control whether unknown deployments should return `404`s or valid responses
- Add default deployment config
- Split generator tests for easier navigation