### PR TITLE
Add per-minute rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ infra/output.json
 __azurite_db_table__.json
 
 .idea/
+
+*.dtmp

--- a/src/aoai-simulated-api/src/aoai_simulated_api/generator/openai.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/generator/openai.py
@@ -244,10 +244,6 @@ def generate_lorem_reference_text_values(token_values: list[int], model_name: st
         generated_texts = [raw_generate_lorem_text(max_tokens, model_name) for _ in range(value_count)]
         values[max_tokens] = generated_texts
 
-    for max_tokens, texts in values.items():
-        actual_tokens = [num_tokens_from_string(text, model_name) for text in texts]
-        print(max_tokens, actual_tokens)
-
     return LoremReference(model_name, values)
 
 

--- a/src/tests/test_openai_generator_embeddings.py
+++ b/src/tests/test_openai_generator_embeddings.py
@@ -139,7 +139,7 @@ async def test_limit_reached():
             assert e.status_code == 429
             assert (
                 e.message
-                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 0 seconds.'}}"
+                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
             )
 
 


### PR DESCRIPTION
- Add per-minute rate limits (works towards #17)
- Add `x-ratelimit-remaining-tokens`/`x-ratelimit-remaining-requests` headers to responses
- skip first/last minute in mean token validation 