### PR TITLE
Update to sample config and docs. Closes #49.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,7 @@
   - [Rate Limiting](#rate-limiting)
   - [Large recordings](#large-recordings)
   - [Config API Endpoint](#config-api-endpoint)
+  - [Open Telemetry](#open-telemetry)
 
 There are a number of [environment variables](#environment-variables) that can be used to configure the simulator.
 Additionally, some configuration can be changed while the simulator is running using the [config endpoint](#config-endpoint).
@@ -126,3 +127,11 @@ For example, the following request will update the mean latency for OpenAI embed
 ```json
 {"latency": {"open_ai_embeddings": {"mean": 1000}}}
 ```
+## Open Telemetry
+
+The simulator supports a set of basic Open Telemetry configuration options. These are:
+
+| Variable| Description |
+| ------- | ----------- |
+| `OTEL_SERVICE_NAME`| Sets the value of the service name reported to Open Telemetry. Defaults to `aoai-simulated-api`|
+| `OTEL_METRIC_EXPORT_INTERVAL`| The time interval (in milliseconds) between the start of two export attempts..|

--- a/sample.env
+++ b/sample.env
@@ -1,18 +1,13 @@
-# Copy this to .env and fill out values
-BASENAME=<insert name here>
-LOCATION='northcentralus'
+# Create a copy of this file called .env, and ensure that all variables have valid values.
 
-# Add values to configure the simulator (see README.md)
-SIMULATOR_MODE=generate
+# Deployment Config
+BASENAME=__CHANGE_ME___                                                         # Prefix for assets deployed into Azure
+LOCATION=__CHANGE_ME___                                                         # Azure region the assets will be deployed to 
 
-# Set this to False to return 404 for deployments that aren't configured
-ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS=True
+# Simulator Config. See config.md for the full set config variables
+SIMULATOR_MODE=generate                                                         # Simulator mode
+OPENAI_DEPLOYMENT_CONFIG_PATH=src/examples/openai_deployment_config.json        # The path to a JSON file that contains the deployment configuration
 
-
-# Set metric export interval (milliseconds)
-OTEL_METRIC_EXPORT_INTERVAL=10000
-
-
-OPENAI_DEPLOYMENT_CONFIG_PATH=src/examples/openai_deployment_config.json
-
-OTEL_SERVICE_NAME=aoai-simulated-api-local-dev
+#  Open Telemetry Config
+OTEL_SERVICE_NAME=aoai-simulated-api-local-dev                                  # The service name used by Open Telemetry
+OTEL_METRIC_EXPORT_INTERVAL=10000                                               # Open Telemetry metric export interval (milliseconds)


### PR DESCRIPTION
Updated and tidied up the `sample.env` removing some of the config in this file where the values were already the defaults.

Updated the docs to refer to the two supported Open Telemetry config values.