### PR TITLE
Fix git dubious ownership issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "bash -c .devcontainer/post-create.sh",
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
I've been hitting errors while using the devcontainer whereby git stops working and then, for some reason, starts working again.

The error I see is...

``` console
fatal: detected dubious ownership in repository at '/workspace'
To add an exception for this directory, call:

    git config --global --add safe.directory /workspace
```

... and the fix suggested here is the same fix given in this article:

https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/

I'm happy to revert/close this PR if there's another way to address this. PR opened to kick off conversation.