### PR TITLE
Fix retry-after to avoid negative retry values

### DIFF
--- a/src/tests/test_openai_generator_embeddings.py
+++ b/src/tests/test_openai_generator_embeddings.py
@@ -129,9 +129,9 @@ async def test_limit_reached():
         assert len(response.choices[0].message.content) > 20
         assert response.choices[0].finish_reason == "length"
 
-        # The total token count for the request is roughly 60 tokens
         # "low_limit" deployment has a rate limit of 600 tokens per minute
-        # Which is 100 every 10s, so our second request should trigger the rate-limiting
+        # So we will trigger the limit based on the number of requests (not tokens)
+        # and it will reset in 10s
         try:
             aoai_client.chat.completions.create(model="low_limit", messages=messages, max_tokens=50)
             assert False, "Expect to be rate-limited"
@@ -139,7 +139,7 @@ async def test_limit_reached():
             assert e.status_code == 429
             assert (
                 e.message
-                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 60 seconds.'}}"
+                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
             )
 
 

--- a/src/tests/test_openai_record.py
+++ b/src/tests/test_openai_record.py
@@ -223,7 +223,8 @@ async def test_openai_record_replay_completion_limit_reached(httpserver: HTTPSer
                 assert False, "Expect to be rate-limited"
             except RateLimitError as e:
                 assert e.status_code == 429
+                # limit should be enforced based on requests (not tokens), so reset in 10s
                 assert (
                     e.message
-                    == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 60 seconds.'}}"
+                    == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
                 )


### PR DESCRIPTION
Update logic so that when we exceed the token/request counts for a window we have a valid retry after interval

Fixes #57 