### PR TITLE
Load test checks

### DIFF
--- a/src/aoai-simulated-api/src/aoai_simulated_api/limiters.py
+++ b/src/aoai-simulated-api/src/aoai_simulated_api/limiters.py
@@ -198,12 +198,12 @@ class SlidingWindow:
                 reason = "requests"
                 retry_after = math.ceil(time_to_reset_requests)
                 if time_to_reset_requests <= 0:
-                    raise Exception("time_to_reset_requests should be greater than 0")
+                    raise ValueError("time_to_reset_requests should be greater than 0")
             else:
                 reason = "tokens"
                 retry_after = math.ceil(time_to_reset_tokens)
                 if time_to_reset_tokens <= 0:
-                    raise Exception("time_to_reset_tokens should be greater than 0")
+                    raise ValueError("time_to_reset_tokens should be greater than 0")
 
             return WindowAddResult(
                 success=False,

--- a/src/loadtest/test_chat_completions_1s_latency.py
+++ b/src/loadtest/test_chat_completions_1s_latency.py
@@ -39,7 +39,7 @@ def on_locust_init(environment: Environment, **_):
 
 
 class ChatCompletionsNoLimitUser(HttpUser):
-    wait_time = constant(1)  # wait 1 second between requests
+    wait_time = constant(0)  # no wait between requests - the latency already adds that!
 
     @task
     def hello_world(self):


### PR DESCRIPTION
- Make load test checks for request/token rate more reliable by converting to per-minute checks and discarding first/last minutes that typically contain fewer requests (KQL aggregation uses wall clock minutes not test time minutes)
- Update wait for metrics check to show latest metric time to make diagnosing issues easier